### PR TITLE
fix scss non-ascii test for ruby 1.9

### DIFF
--- a/static_precompiler/tests/test_scss.py
+++ b/static_precompiler/tests/test_scss.py
@@ -46,7 +46,8 @@ class SCSSTestCase(TestCase):
         )
 
         # Test non-ascii
-        NON_ASCII = """.external_link:first-child:before {
+        NON_ASCII = """@charset "UTF-8";
+.external_link:first-child:before {
   content: "Zobacz także:";
   background: url(картинка.png); }
 """


### PR DESCRIPTION
for details see http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_encoding
