### PR TITLE
Bug fixed : STATIC_ROOT is empty string on Django 1.5.4 / Windows

### DIFF
--- a/static_precompiler/compilers/base.py
+++ b/static_precompiler/compilers/base.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from static_precompiler.models import Dependency
-from static_precompiler.settings import STATIC_ROOT, ROOT, OUTPUT_DIR
+from static_precompiler.settings import STATIC_ROOT, REALLY_STATIC_ROOT, OUTPUT_DIR
 from static_precompiler.utils import get_mtime
 import logging
 import os
@@ -80,7 +80,7 @@ class BaseCompiler(object):
         :returns: str
 
         """
-        return os.path.join(ROOT, self.get_output_path(source_path))
+        return os.path.join(REALLY_STATIC_ROOT, self.get_output_path(source_path))
 
     def get_source_mtime(self, source_path):
         """ Get the modification time of the source file.

--- a/static_precompiler/settings.py
+++ b/static_precompiler/settings.py
@@ -19,6 +19,7 @@ ROOT = getattr(settings, "STATIC_PRECOMPILER_ROOT",
                getattr(settings, "STATIC_ROOT",
                        getattr(settings, "MEDIA_ROOT")))
 STATIC_ROOT = ROOT
+REALLY_STATIC_ROOT = os.path.dirname(getattr(settings, "MEDIA_ROOT"))
 
 OUTPUT_DIR = getattr(settings, "STATIC_PRECOMPILER_OUTPUT_DIR",
                      "COMPILED")


### PR DESCRIPTION
I have no idea why STATIC_ROOT setting is empty string on Django 1.5.4 / Windows, I try to fix it by this way.

Please check it, thank you.
