### PR TITLE
fix scss test for compass 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - npm install -g coffee-script
   - npm install -g less
   - gem install sass --version 3.2.18
-  - gem install compass
+  - gem install compass --version 1.0.0
 install:
   - pip install coveralls
   - pip install django

--- a/static_precompiler/tests/test_scss.py
+++ b/static_precompiler/tests/test_scss.py
@@ -227,7 +227,7 @@ class SCSSTestCase(unittest.TestCase):
         with patch.object(compiler, "compass_enabled", return_value=True):
             self.assertEqual(
                 fix_line_breaks(compiler.compile_file("styles/test-compass-import.scss")),
-                ".round-corners {\n  -webkit-border-radius: 4px 4px;\n  -moz-border-radius: 4px / 4px;\n  border-radius: 4px / 4px; }\n"
+                ".round-corners {\n  -moz-border-radius: 4px / 4px;\n  -webkit-border-radius: 4px 4px;\n  border-radius: 4px / 4px; }\n"
             )
 
         with patch.object(compiler, "compass_enabled", return_value=False):


### PR DESCRIPTION
prior to this change travis fails with

```
FAIL: test_compass_import (static_precompiler.tests.test_scss.SCSSTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/home/travis/build/sir-sigurd/django-static-precompiler/static_precompiler/tests/test_scss.py", line 230, in test_compass_import
".round-corners {\n -webkit-border-radius: 4px 4px;\n -moz-border-radius: 4px / 4px;\n border-radius: 4px / 4px; }\n"
AssertionError: '.round-corners {\n -moz-border-radius: 4px / 4px;\n -webkit-border-radius: 4p [truncated]... != '.round-corners {\n -webkit-border-radius: 4px 4px;\n -moz-border-radius: 4px [truncated]...
.round-corners {
+ -webkit-border-radius: 4px 4px;
-moz-border-radius: 4px / 4px;
- -webkit-border-radius: 4px 4px;
border-radius: 4px / 4px; }
```
