### PR TITLE
readme: fix a typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Django Static Precompiler
 =========================
 
 Django Static Precompiler provides template tags to compile CoffeeScript, SASS / SCSS and LESS.
-It works with both inline code and extenal files.
+It works with both inline code and external files.
 
 .. image:: https://travis-ci.org/andreyfedoseev/django-static-precompiler.svg?branch=master
    :target: https://travis-ci.org/andreyfedoseev/django-static-precompiler


### PR DESCRIPTION
maybe `external` should be replaced by `static`
