### PR TITLE
Fix example for inline compiling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Example Usage
   <script type="text/javascript">
     {% inlinecompile "coffeescript" %}
       console.log "Hello, World!"
-    {% endinlinecoffeescript %}
+    {% endinlinecompile %}
   </script>
 
 renders to::


### PR DESCRIPTION
The example for inline compiling is incorrect.
