### PR TITLE
es6 compiler via 6to5 added

### DIFF
--- a/static_precompiler/compilers/__init__.py
+++ b/static_precompiler/compilers/__init__.py
@@ -1,4 +1,5 @@
 # coding: utf-8
 from static_precompiler.compilers.coffeescript import CoffeeScript
+from static_precompiler.compilers.es6 import ES6Script
 from static_precompiler.compilers.scss import SASS, SCSS
 from static_precompiler.compilers.less import LESS

--- a/static_precompiler/compilers/es6.py
+++ b/static_precompiler/compilers/es6.py
@@ -1,0 +1,23 @@
+from static_precompiler.exceptions import StaticCompilationError
+from static_precompiler.compilers.base import BaseCompiler
+from static_precompiler.settings import ES6_EXECUTABLE
+from static_precompiler.utils import run_command
+
+
+class ES6Script(BaseCompiler):
+    name = "es6"
+    input_extension = "es6"
+    output_extension = "js"
+
+    def compile_file(self, source_path):
+        return self.compile_source(self.get_source(source_path))
+
+    def compile_source(self, source):
+        args = [
+            ES6_EXECUTABLE
+        ]
+        out, errors = run_command(args, source)
+        if errors:
+            raise StaticCompilationError(errors)
+
+        return out

--- a/static_precompiler/settings.py
+++ b/static_precompiler/settings.py
@@ -12,6 +12,7 @@ MTIME_DELAY = getattr(settings, "STATIC_PRECOMPILER_MTIME_DELAY", 10)  # 10 seco
 
 COMPILERS = getattr(settings, "STATIC_PRECOMPILER_COMPILERS", (
     "static_precompiler.compilers.CoffeeScript",
+    "static_precompiler.compilers.ES6Script",
     "static_precompiler.compilers.SASS",
     "static_precompiler.compilers.SCSS",
     "static_precompiler.compilers.LESS",
@@ -42,6 +43,7 @@ CACHE_TIMEOUT = getattr(
 CACHE_NAME = getattr(settings, "STATIC_PRECOMPILER_CACHE_NAME", None)
 
 COFFEESCRIPT_EXECUTABLE = getattr(settings, "COFFEESCRIPT_EXECUTABLE", "coffee")
+ES6_EXECUTABLE = getattr(settings, "ES6_EXECUTABLE", "6to5")
 SCSS_EXECUTABLE = getattr(settings, "SCSS_EXECUTABLE", "sass")
 SCSS_USE_COMPASS = getattr(settings, "SCSS_USE_COMPASS", False)
 LESS_EXECUTABLE = getattr(settings, "LESS_EXECUTABLE", "lessc")

--- a/static_precompiler/templatetags/es6.py
+++ b/static_precompiler/templatetags/es6.py
@@ -1,0 +1,10 @@
+from django.template.base import Library
+from static_precompiler.compilers import ES6Script
+from static_precompiler.templatetags.compile_static import register_compiler_tags
+
+
+register = Library()
+compiler = ES6Script()
+
+
+register_compiler_tags(register, compiler)

--- a/static_precompiler/tests/static/scripts/test.es6
+++ b/static_precompiler/tests/static/scripts/test.es6
@@ -1,0 +1,1 @@
+console.log("Hello, World!");

--- a/static_precompiler/tests/test_es6.py
+++ b/static_precompiler/tests/test_es6.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+from static_precompiler.compilers.es6 import ES6Script
+from static_precompiler.exceptions import StaticCompilationError
+import unittest
+
+
+class ES6ScriptTestCase(unittest.TestCase):
+
+    @staticmethod
+    def clean_javascript(js):
+        """ Remove comments and all blank lines. """
+        return "\n".join(
+            line for line in js.split("\n") if line.strip() and not line.startswith("//")
+        )
+
+    def test_compile_file(self):
+        compiler = ES6Script()
+
+        self.assertEqual(
+            self.clean_javascript(compiler.compile_file("scripts/test.es6")),
+            """"use strict";\nconsole.log("Hello, World!");"""
+        )
+
+    def test_compile_source(self):
+        compiler = ES6Script()
+
+        self.assertEqual(
+            self.clean_javascript(compiler.compile_source('console.log("Hello, World!");')),
+            """"use strict";\nconsole.log("Hello, World!");"""
+        )
+
+        self.assertRaises(
+            StaticCompilationError,
+            lambda: compiler.compile_source('console.log "Hello, World!')
+        )
+
+        # Test non-ascii
+        self.assertEqual(
+            self.clean_javascript(compiler.compile_source('console.log("Привет, Мир!");')),
+            """"use strict";\nconsole.log("Привет, Мир!");"""
+        )
+
+
+def suite():
+    loader = unittest.TestLoader()
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(loader.loadTestsFromTestCase(ES6ScriptTestCase))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
Adds support of ECMAScript 6. For now it handles only files with .es6 ext but it's recommended to use also for .es and .js (which is ambiguous for now).