### PR TITLE
Small fix in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ LESS
 Example::
 
     STATIC_PRECOMPILER_COMPILERS = (
-        ('static_precompiler.less.LESS', {"executable": "/usr/bin/lessc"),
+        ('static_precompiler.compilers.LESS', {"executable": "/usr/bin/lessc"),
     )
 
 
@@ -219,7 +219,7 @@ Stylus
 Example::
 
     STATIC_PRECOMPILER_COMPILERS = (
-        ('static_precompiler.less.Stylus', {"executable": "/usr/bin/stylus"),
+        ('static_precompiler.compilers.Stylus', {"executable": "/usr/bin/stylus"),
     )
 
 


### PR DESCRIPTION
I think it needs to be `static_precompiler.compilers` instead of `static_precompiler.less`; this is also consistent with the setting for `STATIC_PRECOMPILER_COMPILERS`.