### PR TITLE
compiler.handle_changed_file expects verbosity to be int

### DIFF
--- a/static_precompiler/management/commands/compilestatic.py
+++ b/static_precompiler/management/commands/compilestatic.py
@@ -65,7 +65,7 @@ class Command(django.core.management.base.BaseCommand):
                         for compiler in compilers:
                             if compiler.is_supported(path):
                                 try:
-                                    compiler.handle_changed_file(path, verbosity=options["verbosity"])
+                                    compiler.handle_changed_file(path, verbosity=verbosity)
                                 except (exceptions.StaticCompilationError, ValueError) as e:
                                     print(e)
                                 break


### PR DESCRIPTION
There's already `verbosity = int(options["verbosity"])` at line 53