### PR TITLE
Fix documentation of FINDER_LIST_FILES setting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,7 +153,7 @@ General settings
   Disable automatic compilation from template tags or ``compile_static`` utility function. Files are compiled
   only with ``compilestatic`` command (see below). Default: ``False``.
 
-``STATIC_PRECOMPILER_LIST_FILES``
+``STATIC_PRECOMPILER_FINDER_LIST_FILES``
   Whether or not ``static_precompiler.finders.StaticPrecompilerFinder`` will list compiled files when ``collectstatic``
   command is executed. Set to ``True`` if you want compiled files to be found by ``collectstatic``. Default: ``False``.
 


### PR DESCRIPTION
The documentation called the setting `STATIC_PRECOMPILER_LIST_FILES` but
it is actually called `STATIC_PRECOMPILER_FINDER_LIST_FILES` (see
https://github.com/andreyfedoseev/django-static-precompiler/blob/f71bf1b3434b0ee077241ada30dd8648347578ef/static_precompiler/settings.py#L70)