### PR TITLE
Add include_path option for lessc ccommand

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -362,6 +362,9 @@ LESS
 ``sourcemap_enabled``
   Boolean. Set to ``True`` to enable source maps. Default: ``False``.
 
+``include_path``
+  Path (or paths) to use as include paths. From the `docs for lessc <http://lesscss.org/usage/>`_: "If the file in an `@import` rule does not exist at that exact location, less will look for it at the location(s) passed to this option."
+
 ``global_vars``
   Dictionary of global variables (``--global-var`` command line option). Default: ``None``.
 

--- a/static_precompiler/compilers/less.py
+++ b/static_precompiler/compilers/less.py
@@ -21,9 +21,11 @@ class LESS(base.BaseCompiler):
     IMPORT_RE = re.compile(r"@import\s+(.+?)\s*;", re.DOTALL)
     IMPORT_ITEM_RE = re.compile(r"([\"'])(.+?)\1")
 
-    def __init__(self, executable=settings.LESS_EXECUTABLE, sourcemap_enabled=False, global_vars=None):
+    def __init__(self, executable=settings.LESS_EXECUTABLE, sourcemap_enabled=False,
+                 include_path=None, global_vars=None):
         self.executable = executable
         self.is_sourcemap_enabled = sourcemap_enabled
+        self.include_path = include_path
         self.global_vars = global_vars
         super(LESS, self).__init__()
 
@@ -47,6 +49,12 @@ class LESS(base.BaseCompiler):
         if self.is_sourcemap_enabled:
             args.extend([
                 "--source-map"
+            ])
+        if self.include_path:
+            if isinstance(self.include_path, (list, tuple)):
+                self.include_path = ';'.join(self.include_path)
+            args.extend([
+                "--include-path={}".format(self.include_path)
             ])
         if self.global_vars:
             for variable_name, variable_value in self.global_vars.items():
@@ -75,6 +83,12 @@ class LESS(base.BaseCompiler):
             self.executable,
             "-"
         ]
+        if self.include_path:
+            if isinstance(self.include_path, (list, tuple)):
+                self.include_path = ';'.join(self.include_path)
+            args.extend([
+                "--include-path={}".format(self.include_path)
+            ])
 
         return_code, out, errors = utils.run_command(args, source)
 


### PR DESCRIPTION
When doing inline pre-compiling, it would be nice to still be able to use the @import rule. However, it is not always clear to lessc what path should be used for the import. The lessc option `--include-path` lets you specify where to look for unknown import path locations.

This pull request adds the `include_path` option which can be specified in the settings file.