### PR TITLE
Replace hard-coded path separator with os.sep

### DIFF
--- a/static_precompiler/management/commands/compilestatic.py
+++ b/static_precompiler/management/commands/compilestatic.py
@@ -25,9 +25,7 @@ def list_files(scanned_dirs):
     for scanned_dir in scanned_dirs:
         for dirname, dirnames, filenames in os.walk(scanned_dir):
             for filename in filenames:
-                path = os.path.join(dirname, filename)[len(scanned_dir):]
-                if path.startswith("/"):
-                    path = path[1:]
+                path = os.path.join(dirname, filename)[len(scanned_dir):].lstrip(os.sep)
                 yield path
 
 


### PR DESCRIPTION
This allows paths to be correctly created on all OSes including Windows.