### PR TITLE
Adds Django 3.0 and 3.1 tested compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: ubuntu:focal
     steps:
       # steps from Dockerfile-base
-      - run: apt-get -y update && apt-get install -y autoconf libtool ruby-dev npm
+      - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends autoconf libtool ruby-dev npm
       - run: ln -s /usr/bin/nodejs /usr/local/bin/node
       - run: npm install -g coffee-script@1.7.1
       - run: npm install -g livescript@1.4.0
@@ -17,7 +17,7 @@ jobs:
       - run: gem install sass -v 3.4.22
       - run: gem install compass -v 1.0.1
       # original steps
-      - run: apt-get -y update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
+      - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
       - run: pip install -r requirements-ci.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
     docker:
       - image: andreyfedoseev/django-static-precompiler
     steps:
-      - run: apt-get install software-properties-common && apt-get update
-      - run: add-apt-repository ppa:deadsnakes/ppa && apt-get update
+      - run: apt-get -y install software-properties-common && apt-get -y update
+      - run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get -y update
       - run: apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
+      - run: pip install setuptools
       - run: pip install -r requirements-ci.txt
       - run: pip install -e .[libsass]
       - run: flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run: npm install -g coffee-script@1.7.1
       - run: npm install -g livescript@1.4.0
       - run: npm install -g less@1.7.4
-      - run: npm install -g babel-cli@7.12.10
+      - run: npm install -g babel-cli@6.26.0
       - run: npm install -g stylus@0.54.8
       - run: npm install -g handlebars@4.7.6
       - run: gem install sass -v 3.7.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: andreyfedoseev/django-static-precompiler
     steps:
-      - run: apt-get update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
+      - run: add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
       - run: pip install -r requirements-ci.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm install -g babel-cli@7.0.0-beta.3
       - run: npm install -g stylus@0.54.8
       - run: npm install -g handlebars@4.7.6
-      - run: gem install sass -v 3.7.4
+      - run: gem install sass -v 3.4.22
       - run: gem install compass -v 1.0.1
       # original steps
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/django-static-precompiler
     docker:
-      - image: ubuntu:focal
+      - image: ubuntu:bionic
     steps:
       # steps from Dockerfile-base -- updated versions
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends autoconf libtool ruby-dev npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
       - run: npm install -g stylus@0.54.8
       - run: npm install -g handlebars@4.7.6
       - run: gem install sass -v 3.4.22
-      - run: gem install compass -v 1.0.1
+      - run: DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential
+      - run: gem install compass -v 1.0.3
       # original steps
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,16 @@ jobs:
     docker:
       - image: ubuntu:focal
     steps:
-      # steps from Dockerfile-base
+      # steps from Dockerfile-base -- updated versions
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends autoconf libtool ruby-dev npm
       - run: ln -s /usr/bin/nodejs /usr/local/bin/node
       - run: npm install -g coffee-script@1.7.1
       - run: npm install -g livescript@1.4.0
       - run: npm install -g less@1.7.4
-      - run: npm install -g babel-cli@6.2.0
-      - run: npm install -g stylus@0.50.0
-      - run: npm install -g handlebars@4.0.2
-      - run: gem install sass -v 3.4.22
+      - run: npm install -g babel-cli@7.12.10
+      - run: npm install -g stylus@0.54.8
+      - run: npm install -g handlebars@4.7.6
+      - run: gem install sass -v 3.7.4
       - run: gem install compass -v 1.0.1
       # original steps
       - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,12 @@ jobs:
       - run: npm install -g less@1.7.4
       - run: npm install -g babel-cli@7.0.0-beta.3
       - run: npm install -g stylus@0.54.8
-      - run: npm install -g handlebars@4.7.6
+      - run: npm install -g handlebars@4.0.2
       - run: gem install sass -v 3.4.22
       - run: DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential
       - run: gem install compass -v 1.0.3
-      # original steps
-      - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3
+      # original steps -- updated
+      - run: apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2.7-dev python3.6-dev python-pip sqlite3 python3-distutils
       - checkout
       - run: pip install --upgrade pip
       - run: pip install setuptools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: andreyfedoseev/django-static-precompiler
     steps:
-      - run: apt-get update && apt-get install -y python2.7-dev python3.5-dev python-pip sqlite3
+      - run: apt-get update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
       - run: pip install -r requirements-ci.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run: npm install -g coffee-script@1.7.1
       - run: npm install -g livescript@1.4.0
       - run: npm install -g less@1.7.4
-      - run: npm install -g babel-cli@6.26.0
+      - run: npm install -g babel-cli@7.0.0-beta.3
       - run: npm install -g stylus@0.54.8
       - run: npm install -g handlebars@4.7.6
       - run: gem install sass -v 3.7.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,21 @@ jobs:
   build:
     working_directory: ~/django-static-precompiler
     docker:
-      - image: andreyfedoseev/django-static-precompiler
+      - image: ubuntu:focal
     steps:
-      - run: apt-get -y install software-properties-common && apt-get -y update
-      - run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get -y update
-      - run: apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
+      # steps from Dockerfile-base
+      - run: apt-get -y update && apt-get install -y autoconf libtool ruby-dev npm
+      - run: ln -s /usr/bin/nodejs /usr/local/bin/node
+      - run: npm install -g coffee-script@1.7.1
+      - run: npm install -g livescript@1.4.0
+      - run: npm install -g less@1.7.4
+      - run: npm install -g babel-cli@6.2.0
+      - run: npm install -g stylus@0.50.0
+      - run: npm install -g handlebars@4.0.2
+      - run: gem install sass -v 3.4.22
+      - run: gem install compass -v 1.0.1
+      # original steps
+      - run: apt-get -y update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
       - run: pip install -r requirements-ci.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
     docker:
       - image: andreyfedoseev/django-static-precompiler
     steps:
-      - run: add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
+      - run: apt-get install software-properties-common && apt-get update
+      - run: add-apt-repository ppa:deadsnakes/ppa && apt-get update
+      - run: apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
       - checkout
       - run: pip install --upgrade pip
       - run: pip install -r requirements-ci.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM andreyfedoseev/django-static-precompiler
 MAINTAINER Andrey Fedoseev <andrey.fedoseev@gmail.com>
-RUN apt-get update && apt-get install -y python2.7-dev python3.5-dev python-pip sqlite3
+RUN apt-get update && apt-get install -y python2.7-dev python3.6-dev python-pip sqlite3
 RUN mkdir /app
 WORKDIR /app
 ADD requirements-*.txt /app/

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
 -r requirements-test.txt
-flake8
-codecov
+flake8==3.8.4
+codecov==2.1.11

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
-pytest<4
+pytest==3.10.1
 pytest-django==3.1.2
-pretend
-watchdog
-libsass
-coverage
+pretend==1.0.9
+watchdog==0.10.6
+libsass==0.20.1
+coverage==5.3.1
 pytest-cov==2.5.1
-tox
+tox==3.20.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest==3.10.1
 pytest-django==3.1.2
 pretend==1.0.9
-watchdog==0.10.6
+watchdog
 libsass==0.20.1
 coverage==5.3.1
 pytest-cov==2.5.1

--- a/static_precompiler/compilers/base.py
+++ b/static_precompiler/compilers/base.py
@@ -4,7 +4,13 @@ import posixpath
 
 import django.core.exceptions
 from django.contrib.staticfiles import finders
-from django.utils import encoding, functional, six
+from django.utils import encoding, functional
+
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
 
 from .. import models, mtime, settings, utils
 
@@ -207,7 +213,7 @@ class BaseCompiler(object):
         """
         return encoding.force_text(self.compile(source_path))
 
-    compile_lazy = functional.lazy(compile_lazy, six.text_type)
+    compile_lazy = functional.lazy(compile_lazy, six.text_type if uses_six else str)
 
     def compile_file(self, source_path):
         """ Compile the source file. Return the relative path to compiled file.

--- a/static_precompiler/registry.py
+++ b/static_precompiler/registry.py
@@ -3,7 +3,12 @@ import warnings
 
 import django.apps
 import django.core.exceptions
-from django.utils import six
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
+
 from typing import Dict
 
 from . import exceptions, settings
@@ -73,7 +78,7 @@ def get_compiler_by_name(name):
 
 def get_compiler_by_path(path):
     # type: (str) -> BaseCompiler
-    for compiler in six.itervalues(get_compilers()):
+    for compiler in (six.itervalues(get_compilers()) if uses_six else get_compilers().values()):
         if compiler.is_supported(path):
             return compiler
 

--- a/static_precompiler/templatetags/compile_static.py
+++ b/static_precompiler/templatetags/compile_static.py
@@ -2,7 +2,11 @@ import warnings
 
 import django.template
 import django.templatetags.static
-from django.utils import six
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
 
 from .. import caching, registry, settings, utils
 
@@ -46,7 +50,7 @@ class InlineCompileNode(django.template.Node):
         else:
             compiler = django.template.Variable(self.compiler).resolve(context)
 
-        if isinstance(compiler, six.string_types):
+        if isinstance(compiler, six.string_types if uses_six else str):
             compiler = registry.get_compiler_by_name(compiler)
 
         if settings.USE_CACHE:

--- a/static_precompiler/tests/test_utils.py
+++ b/static_precompiler/tests/test_utils.py
@@ -3,7 +3,12 @@ from __future__ import unicode_literals
 
 import os
 
-from django.utils import six
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
+
 from pretend import stub
 
 from static_precompiler import utils
@@ -16,7 +21,7 @@ def test_write_read_file(tmpdir, settings):
 
     assert os.path.exists(path)
     read_content = utils.read_file(path)
-    assert isinstance(read_content, six.text_type)
+    assert isinstance(read_content, six.text_type if uses_six else str)
     assert read_content == "Привет, Мир!"
 
 

--- a/static_precompiler/url_converter.py
+++ b/static_precompiler/url_converter.py
@@ -1,11 +1,15 @@
 import os
 import re
 
-from django.utils import six
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
 
 from . import settings, utils
 
-if six.PY2:
+if uses_six and six.PY2:
     # noinspection PyUnresolvedReferences,PyCompatibility
     from urlparse import urljoin
 else:

--- a/static_precompiler/utils.py
+++ b/static_precompiler/utils.py
@@ -30,7 +30,7 @@ def read_file(path):
         with open(path) as file_object:
             return file_object.read().decode(django.conf.settings.FILE_CHARSET)
     else:
-        with open(path, encoding=django.conf.settings.FILE_CHARSET) as file_object:
+        with open(path, encoding=django.conf.settings.get('FILE_CHARSET', 'utf-8')) as file_object:
             return file_object.read()
 
 
@@ -44,7 +44,7 @@ def write_file(content, path):
         with open(path, "w+") as file_object:
             file_object.write(content.encode(django.conf.settings.FILE_CHARSET))
     else:
-        with open(path, "w+", encoding=django.conf.settings.FILE_CHARSET) as file_object:
+        with open(path, "w+", encoding=django.conf.settings.get('FILE_CHARSET', 'utf-8')) as file_object:
             file_object.write(content)
 
 

--- a/static_precompiler/utils.py
+++ b/static_precompiler/utils.py
@@ -16,7 +16,7 @@ except ImportError:
 from . import settings
 
 
-def _django_conf_file_charset() -> str:
+def _django_conf_file_charset():
     """
     From Django 3.1 on, FILE_CHARSET must be 'utf-8'.
     """

--- a/static_precompiler/utils.py
+++ b/static_precompiler/utils.py
@@ -16,6 +16,16 @@ except ImportError:
 from . import settings
 
 
+def _django_conf_file_charset() -> str:
+    """
+    From Django 3.1 on, FILE_CHARSET must be 'utf-8'.
+    """
+    try:
+        return django.conf.settings.FILE_CHARSET
+    except AttributeError:
+        return 'utf-8'
+
+
 def normalize_path(posix_path):
     """ Convert posix style path to OS-dependent path.
     """
@@ -28,9 +38,9 @@ def read_file(path):
     """ Return the contents of a file as unicode. """
     if uses_six and six.PY2:
         with open(path) as file_object:
-            return file_object.read().decode(django.conf.settings.FILE_CHARSET)
+            return file_object.read().decode(_django_conf_file_charset())
     else:
-        with open(path, encoding=django.conf.settings.get('FILE_CHARSET', 'utf-8')) as file_object:
+        with open(path, encoding=_django_conf_file_charset()) as file_object:
             return file_object.read()
 
 
@@ -42,9 +52,9 @@ def write_file(content, path):
 
     if uses_six and six.PY2:
         with open(path, "w+") as file_object:
-            file_object.write(content.encode(django.conf.settings.FILE_CHARSET))
+            file_object.write(content.encode(_django_conf_file_charset()))
     else:
-        with open(path, "w+", encoding=django.conf.settings.get('FILE_CHARSET', 'utf-8')) as file_object:
+        with open(path, "w+", encoding=_django_conf_file_charset()) as file_object:
             file_object.write(content)
 
 

--- a/static_precompiler/utils.py
+++ b/static_precompiler/utils.py
@@ -6,7 +6,12 @@ import subprocess
 import django.conf
 import django.core.cache
 import django.core.exceptions
-from django.utils import encoding, six
+from django.utils import encoding
+try:
+    from django.utils import six
+    uses_six = True
+except ImportError:
+    uses_six = False
 
 from . import settings
 
@@ -21,7 +26,7 @@ def normalize_path(posix_path):
 
 def read_file(path):
     """ Return the contents of a file as unicode. """
-    if six.PY2:
+    if uses_six and six.PY2:
         with open(path) as file_object:
             return file_object.read().decode(django.conf.settings.FILE_CHARSET)
     else:
@@ -35,7 +40,7 @@ def write_file(content, path):
     # Convert to unicode
     content = encoding.force_text(content)
 
-    if six.PY2:
+    if uses_six and six.PY2:
         with open(path, "w+") as file_object:
             file_object.write(content.encode(django.conf.settings.FILE_CHARSET))
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ envlist =
     py35-django20,
     py35-django21,
     py35-django22,
+    py35-django30,
+    py35-django31,
 
 [testenv]
 passenv = GEM_PATH
@@ -24,6 +26,8 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 commands = py.test static_precompiler --cov static_precompiler --cov-report xml --cov-append
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,14 @@ envlist =
     py27-django19,
     py27-django110,
     py27-django111,
-    py35-django19,
-    py35-django110,
-    py35-django111,
-    py35-django20,
-    py35-django21,
-    py35-django22,
-    py35-django30,
-    py35-django31,
+    py36-django19,
+    py36-django110,
+    py36-django111,
+    py36-django20,
+    py36-django21,
+    py36-django22,
+    py36-django30,
+    py36-django31,
 
 [testenv]
 passenv = GEM_PATH


### PR DESCRIPTION
Makes PR#125 "Stop using django.utils.six" progressively stop using six, so the code stays compatible with old versions.

Closes #124

Ref: https://github.com/andreyfedoseev/django-static-precompiler/pull/125
Thanks to: @cafehaine 