### PR TITLE
Fix #95

### DIFF
--- a/static_precompiler/compilers/libsass.py
+++ b/static_precompiler/compilers/libsass.py
@@ -45,7 +45,10 @@ class SCSS(scss.SCSS):
         try:
             if self.is_sourcemap_enabled:
                 compiled, sourcemap = sass.compile(
-                    filename=full_source_path, source_map_filename=sourcemap_path, include_paths=self.load_paths
+                    filename=full_source_path,
+                    source_map_filename=sourcemap_path,
+                    output_filename_hint=full_output_path,
+                    include_paths=self.load_paths,
                 )
             else:
                 compile_kwargs = {}


### PR DESCRIPTION
Using parameter `output_filename_hint` when compiling scss with libsass, should fix the wrongly generated `sourceMappingURL`. At least it fixed the problem for me.

Fixes: https://github.com/andreyfedoseev/django-static-precompiler/issues/95
Related: https://github.com/sass/libsass-python/issues/201
