### PR TITLE
fix url_converter.py using greedy regex to find URLs

### DIFF
--- a/static_precompiler/url_converter.py
+++ b/static_precompiler/url_converter.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from . import settings, utils
 
-URL_PATTERN = re.compile(r"url\((.+)\)")
+URL_PATTERN = re.compile(r"url\((.+?)\)")
 
 
 def convert_url(url, source_dir):


### PR DESCRIPTION
The url_converters uses a greedy regex to find URLs, and can cause incorrect output. Here is a simple test case:

    // SCSS
    #features details {
      background: url("/static/profile/ui/img/asideicons.png") no-repeat;
    }
    
    @media (min-width: 768px) {
      #bodyContent {
        margin-top: 300px;
      }
    }

    // Output:
    #features details{background:url("/static/profile/ui/img/asideicons.png") no-repeat}@media(min-width: 768px"){#bodyContent{margin-top:300px}}/*# sourceMappingURL=sass_bug_repro.css.map */

    // Expected output:
    
    #features details{background:url("/static/profile/ui/img/asideicons.png") no-repeat}@media(min-width: 768px){#bodyContent{margin-top:300px}}/*# sourceMappingURL=sass_bug_repro.css.map */
    
Note the stray double-quote character in `media(min-width: 768px")`.

This happens because the repetition quantifier in the regex used is greedy, and runs all the way up until the very last ')' in the file. The solution is to use a lazy quantifier, which runs to the first ')' that it sees.

Note that this is an incomplete fix - regex is not suitable for parsing CSS, and this regex cannot parse things like:

`url("file_\"with\"quotes_in_name.png")` or
`url("file (Copy).png")`

For that, a real parser would be needed.
