### PR TITLE
Use empty list instead of False boolean in requires_system_checks

### DIFF
--- a/static_precompiler/management/commands/compilestatic.py
+++ b/static_precompiler/management/commands/compilestatic.py
@@ -83,7 +83,7 @@ class Command(django.core.management.base.BaseCommand):
 
     help = "Compile static files."
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         for argument, parameters in ARGUMENTS:


### PR DESCRIPTION
This fixes #149 and is required for Django 4.1 support