### PR TITLE
Do not run coverage report paralelly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ shell:
 	docker compose run --rm app /bin/bash
 
 test:
+	docker compose run --rm app pytest --cov static_precompiler --cov-report xml --cov-append
 	docker compose run --rm app tox -p auto
 
 check-types:

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ deps =
     django32: Django~=3.2.0
     django42: Django~=4.2.0
     django52: Django~=5.2.0
-commands = poetry run pytest --cov static_precompiler --cov-report xml --cov-append
+commands = poetry run pytest


### PR DESCRIPTION
There were file conflict error almost every time, and I was not able to figure out why different coverage instances wanted to use the same temporary file.

I hope this will finally fix the build error: https://github.com/andreyfedoseev/django-static-precompiler/pull/171#issuecomment-2907643851